### PR TITLE
bugfix Update groups.page.ts

### DIFF
--- a/src/app/pages/groups/groups.page.ts
+++ b/src/app/pages/groups/groups.page.ts
@@ -11,7 +11,7 @@ import { Component, OnInit } from '@angular/core';
 })
 export class GroupsPage implements OnInit {
   user = this.authService.getCurrentUser();
-  groups = [];
+  groups: { title: any; id: any; users: { email: any; }[]; }[] | null = null;
 
   constructor(
     private authService: AuthService,


### PR DESCRIPTION
removes the following error message:
Type '{ title: any; id: any; users: { email: any; }[]; }[] | null' is not assignable to type 'never[]'.
  Type 'null' is not assignable to type 'never[]'.ts(2322)